### PR TITLE
Update description in Jenkins plugins screen

### DIFF
--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,7 +1,4 @@
 <?jelly escape-by-default='true'?>
-<!--
-  This view is used to render the installed plugins page.
--->
 <div>
-  This plugin is a sample to explain how to write a Jenkins plugin.
+  Adds support for <a href="https://flywaydb.org/documentation">Flyway</a> (the open-source database migration tool) as an available build step.
 </div>


### PR DESCRIPTION
When listing the plugin in the the Jenkins plugins screen the default description generated by the Maven archetype is still visible. This is to fix that.
<img width="428" alt="image" src="https://user-images.githubusercontent.com/10434613/87153278-84bcf080-c2b7-11ea-8beb-ba327afdeea5.png">
