### PR TITLE
fix: duplicate build descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.6</version>
+        <version>4.16</version>
         <relativePath />
     </parent>
     <groupId>sp.sd</groupId>
@@ -14,9 +14,8 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>1.651.3</jenkins.version>
+        <jenkins.version>2.277.4</jenkins.version>
         <java.level>8</java.level>
-        <jenkins-test-harness.version>2.3</jenkins-test-harness.version>
         <flyway.install.version>4.0.3</flyway.install.version>
         <flyway.home>${project.build.directory}/flyway-${flyway.install.version}</flyway.home>
     </properties>
@@ -48,22 +47,33 @@
         <tag>HEAD</tag>
     </scm>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.277.x</artifactId>
+                <version>25</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.41</version>
+            <version>1.66</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
@@ -80,13 +90,12 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.178</version>
+            <version>1.4.191</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness-tools</artifactId>
-            <version>2.0</version>
+            <artifactId>jenkins-test-harness</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <jenkins.version>1.651.3</jenkins.version>
-        <java.level>7</java.level>
+        <java.level>8</java.level>
         <jenkins-test-harness.version>2.3</jenkins-test-harness.version>
         <flyway.install.version>4.0.3</flyway.install.version>
         <flyway.home>${project.build.directory}/flyway-${flyway.install.version}</flyway.home>

--- a/src/main/java/sp/sd/flywayrunner/builder/FlywayBuilder.java
+++ b/src/main/java/sp/sd/flywayrunner/builder/FlywayBuilder.java
@@ -244,7 +244,6 @@ public class FlywayBuilder extends Builder implements SimpleBuildStep, Serializa
     }
 
 
-    @Extension
     @Symbol("flywayrunner")
     public static final class StepDescriptor<C extends StandardCredentials> extends BuildStepDescriptor<Builder> {
         @CopyOnWrite

--- a/src/test/java/sp/sd/flywayrunner/builder/InstallerTest.java
+++ b/src/test/java/sp/sd/flywayrunner/builder/InstallerTest.java
@@ -37,7 +37,7 @@ public class InstallerTest {
         HtmlElement addButton = configure.getFirstByXPath("//button[contains(., 'Add Flyway')]");
         addButton.click();
         List<HtmlElement> versionOptions =
-                (List<HtmlElement>) configure.getByXPath("//div[contains(@descriptorid, 'FlywayInstaller')]//option");
+                configure.getByXPath("//div[contains(@descriptorid, 'FlywayInstaller')]//option");
 
         assertThat(versionOptions, hasSize(20));
         assertThat(versionOptions, hasItem(isOptionWithVersionText("4.0.3 (without JRE)")));


### PR DESCRIPTION
Jenkins 2.x Fixed an issue where Invoke Flyway would be displayed dupe.

multi Extension anotation remove.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
